### PR TITLE
printable.txtのバリデーション

### DIFF
--- a/srcs/t3_glyph.c
+++ b/srcs/t3_glyph.c
@@ -79,6 +79,29 @@ static bool	convert_glyph_to_points(t_glyph *glyph,
 	return (true);
 }
 
+void	validate_glyph_file(char ***lines_ptr)
+{
+	char	**lines;
+
+	lines = *lines_ptr;
+	while (*lines)
+	{
+		if (strlen(*lines) != T3_GLYPH_WIDTH)
+		{
+			t3_destroy_strarray(*lines_ptr);
+			dprintf(STDERR_FILENO, "Error: printable.txt: invalid file.\n");
+			exit(1);
+		}
+		lines += 1;
+	}
+	if (lines - *lines_ptr != T3_GLYPH_HEIGHT * T3_GLYPH_NUM)
+	{
+		t3_destroy_strarray(*lines_ptr);
+		dprintf(STDERR_FILENO, "Error: printable.txt: invalid file.\n");
+		exit(1);
+	}
+}
+
 // グリフファイルからグリフを読み取り、t_glyph配列に格納する。
 // 読み取れたグリフの数を返す(最大でT3_GLYPH_NUM)。
 size_t	t3_read_glyphs(t_glyph *glyphs)
@@ -91,6 +114,7 @@ size_t	t3_read_glyphs(t_glyph *glyphs)
 	lines = t3_read_all_lines(T3_GLYPH_FILE);
 	if (!lines)
 		return (0);
+	validate_glyph_file(&lines);
 	i = 0;
 	next_start_line = 0;
 	curr_start_line = 0;

--- a/srcs/t3_glyph.c
+++ b/srcs/t3_glyph.c
@@ -89,7 +89,7 @@ void	validate_glyph_file(char ***lines_ptr)
 		if (strlen(*lines) != T3_GLYPH_WIDTH)
 		{
 			t3_destroy_strarray(*lines_ptr);
-			dprintf(STDERR_FILENO, "Error: printable.txt: invalid file.\n");
+			dprintf(STDERR_FILENO, "Error: %s: invalid file.\n", T3_GLYPH_FILE);
 			exit(1);
 		}
 		lines += 1;
@@ -97,7 +97,7 @@ void	validate_glyph_file(char ***lines_ptr)
 	if (lines - *lines_ptr != T3_GLYPH_HEIGHT * T3_GLYPH_NUM)
 	{
 		t3_destroy_strarray(*lines_ptr);
-		dprintf(STDERR_FILENO, "Error: printable.txt: invalid file.\n");
+		dprintf(STDERR_FILENO, "Error: %s: invalid file.\n", T3_GLYPH_FILE);
 		exit(1);
 	}
 }


### PR DESCRIPTION
## やったこと
バリデーションで不正だった場合はメモリ解放してexit status を1にして終了します。
## やらないこと

## テスト
printable.txtの1行の文字数を変えたり、行数を増やしてテストしてください。
## その他
