### PR TITLE
入力の拡張子チェックとファイル分割

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,10 @@ DEBUG_FLAGS = -g3
 
 FILES = ft_raw_split.c \
         ft_split.c \
-        ft_cntchr.c \
+        ft_minilib.c \
         main.c \
         rd_file.c \
+        t3_source.c \
         t3_affine.c \
         t3_affine_compose.c \
         t3_double.c \

--- a/includes/term3d.h
+++ b/includes/term3d.h
@@ -128,11 +128,11 @@ typedef struct s_optics {
 // transform_static:   回転直前までもっていくアフィン変換
 // transform_animated: 回転適用後のアフィン変換
 // src_mode:           描画するものが何なのか
-// n_glyphs:           グリフの数
-// gliphs:             グリフのデータ
+// glyphs:             グリフのデータ
 // message:            任意入力メッセージ
 // len_message:        現在のメッセージ長
-// n_pixelbuffer:      ピクセルバッファのサイズ
+// printbuffer:        プリントバッファ; ターミナルにwriteされる文字列データ。
+// n_printbuffer:      プリントバッファの**実際の**サイズ
 typedef struct s_system {
 	size_t		n_points;
 	t_vector3d	*points_original;
@@ -148,8 +148,8 @@ typedef struct s_system {
 	char		message[T3_MAX_MSGLEN + 1];
 	size_t		len_message;
 
-	size_t		n_pixelbuffer;
 	char		printbuffer[T3_MAX_HEIGHT * (T3_MAX_WIDTH + 1)];
+	size_t		n_printbuffer;
 }	t_system;
 
 char		**ft_rawsplit(char const *s, char c);

--- a/includes/term3d.h
+++ b/includes/term3d.h
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/14 22:58:31 by corvvs            #+#    #+#             */
-/*   Updated: 2022/02/23 11:43:07 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/02/23 18:01:25 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,7 @@
 # define T3_MAX_WIDTH 350
 # define T3_MAX_HEIGHT 100
 # define T3_GLYPH_FILE "./printables.txt"
+# define T3_EXTENSION_3D ".3d"
 // グリフ総数
 # define T3_GLYPH_NUM 96
 // 1つのグリフの横幅(文字数)
@@ -65,6 +66,8 @@ typedef enum e_source {
 	T3_SRC_DUMMY,
 	T3_SRC_TEXT,
 	T3_SRC_FILE_3D,
+	T3_SRC_FILE_UNEXPECTED,
+	T3_SRC_TOO_MANY,
 }	t_source;
 
 # define T3_CBEZIER_SIZE 1000
@@ -152,6 +155,9 @@ typedef struct s_system {
 char		**ft_rawsplit(char const *s, char c);
 char		**ft_split(char const *s, char c);
 size_t		ft_cntchr(const char *str, char c);
+bool		ft_str_ensdwith(const char *str, const char *suffix);
+
+void		t3_read_source(t_system *system, int argc, char **argv);
 
 char		**t3_read_all_lines(const char *file_path);
 char		*t3_read_from_fd(const int fd);

--- a/includes/term3d.h
+++ b/includes/term3d.h
@@ -155,7 +155,7 @@ typedef struct s_system {
 char		**ft_rawsplit(char const *s, char c);
 char		**ft_split(char const *s, char c);
 size_t		ft_cntchr(const char *str, char c);
-bool		ft_str_ensdwith(const char *str, const char *suffix);
+bool		ft_str_endswith(const char *str, const char *suffix);
 
 void		t3_read_source(t_system *system, int argc, char **argv);
 

--- a/srcs/ft_minilib.c
+++ b/srcs/ft_minilib.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_cntchr.c                                        :+:      :+:    :+:   */
+/*   ft_minilib.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2022/02/23 02:28:18 by corvvs            #+#    #+#             */
-/*   Updated: 2022/02/23 02:29:31 by corvvs           ###   ########.fr       */
+/*   Created: 2022/02/23 18:00:25 by corvvs            #+#    #+#             */
+/*   Updated: 2022/02/23 18:00:26 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,4 +24,14 @@ size_t	ft_cntchr(const char *str, char c)
 		++str;
 	}
 	return (n);
+}
+
+bool	ft_str_ensdwith(const char *str, const char *suffix)
+{
+	const size_t	nstr = strlen(str);
+	const size_t	nsuffix = strlen(suffix);
+
+	if (nstr < nsuffix)
+		return (false);
+	return (strcmp(str + (nstr - nsuffix), suffix) == 0);
 }

--- a/srcs/ft_minilib.c
+++ b/srcs/ft_minilib.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/23 18:00:25 by corvvs            #+#    #+#             */
-/*   Updated: 2022/02/23 18:00:26 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/02/23 18:26:55 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ size_t	ft_cntchr(const char *str, char c)
 	return (n);
 }
 
-bool	ft_str_ensdwith(const char *str, const char *suffix)
+bool	ft_str_endswith(const char *str, const char *suffix)
 {
 	const size_t	nstr = strlen(str);
 	const size_t	nsuffix = strlen(suffix);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,56 +6,19 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/14 22:57:24 by corvvs            #+#    #+#             */
-/*   Updated: 2022/02/23 11:10:19 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/02/23 18:04:56 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "term3d.h"
 
-// STDIN_FILENO を /dev/tty/stdin に割り当て直す
-int	stdin_to_tty(void)
-{
-	close(STDIN_FILENO);
-	return (dup2(STDOUT_FILENO, STDIN_FILENO));
-}
-
-void	t3_handle_text(t_system *system)
-{
-	system->src_mode = T3_SRC_TEXT;
-	if (!t3_read_glyphs(system->glyphs))
-	{
-		dprintf(STDERR_FILENO, T3_COLOR_YELLOW
-			"Error: %s: failed to read glyth file."
-			T3_COLOR_RESET "\n", T3_GLYPH_FILE);
-		exit(1);
-	}
-	t3_scan_message(system);
-	stdin_to_tty();
-}
-
-void	t3_handle_file(t_system *system, char *filename)
-{
-	system->src_mode = T3_SRC_FILE_3D;
-	system->points_original = t3_read_vectors_from_file(filename);
-	if (!system->points_original)
-		exit(1);
-	system->n_points = 0;
-	while (isfinite(system->points_original[system->n_points][0]))
-		system->n_points += 1;
-}
-
 int	main(int argc, char **argv)
 {
 	t_system	system;
 
-	if (argc > 2)
-		exit(1);
 	t3_check_tty_out();
 	bzero(&system, sizeof(t_system));
-	if (argc == 1)
-		t3_handle_text(&system);
-	else
-		t3_handle_file(&system, argv[1]);
+	t3_read_source(&system, argc, argv);
 	t3_setup_system(&system);
 	t3_render_loop(&system);
 }

--- a/srcs/t3_render.c
+++ b/srcs/t3_render.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/20 16:02:43 by tkomatsu          #+#    #+#             */
-/*   Updated: 2022/02/23 11:33:46 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/02/23 13:44:27 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -93,6 +93,5 @@ void	t3_render(t_system *system)
 	fill_pixelbuffer(system);
 	write(STDOUT_FILENO, T3_ES_CLEAR, strlen(T3_ES_CLEAR));
 	fill_printbuffer(system);
-	write(STDOUT_FILENO, system->printbuffer,
-		system->optics.height * (system->optics.width + 1));
+	write(STDOUT_FILENO, system->printbuffer, system->n_printbuffer);
 }

--- a/srcs/t3_setup.c
+++ b/srcs/t3_setup.c
@@ -6,11 +6,22 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/20 15:38:46 by tkomatsu          #+#    #+#             */
-/*   Updated: 2022/02/23 11:36:34 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/02/23 18:06:42 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "term3d.h"
+
+static t_cubic_bezier	cubic_bezier(double x1, double y1, double x2, double y2)
+{
+	t_cubic_bezier	cb;
+
+	cb.x1 = x1;
+	cb.y1 = y1;
+	cb.x2 = x2;
+	cb.y2 = y2;
+	return (cb);
+}
 
 // stdoutはどちらもターミナルになっている必要がある。
 // (まともな出力と、stdinをターミナルに向け直すために必要)
@@ -24,18 +35,7 @@ void	t3_check_tty_out(void)
 	exit(1);
 }
 
-static t_cubic_bezier	cubic_bezier(double x1, double y1, double x2, double y2)
-{
-	t_cubic_bezier	cb;
-
-	cb.x1 = x1;
-	cb.y1 = y1;
-	cb.x2 = x2;
-	cb.y2 = y2;
-	return (cb);
-}
-
-// opticsの設定
+// set all initial parameters of optics.
 void	t3_init_render_params(t_system *system)
 {
 	struct winsize	ws;
@@ -56,13 +56,12 @@ void	t3_init_render_params(t_system *system)
 	system->optics.t = 0;
 	system->optics.fps = 120;
 	system->optics.us_per_frame = 1000000 / system->optics.fps;
-	system->n_pixelbuffer
+	system->n_printbuffer
 		= system->optics.height * (system->optics.width + 1);
 	system->optics.bezier = cubic_bezier(0.68, -0.6, 0.32, 1.6);
 	t3_setup_cubic_bezier(&system->optics.bezier);
 }
 
-// [処理用データ構造の初期化]
 void	t3_setup_system(t_system *system)
 {
 	t3_init_render_params(system);

--- a/srcs/t3_source.c
+++ b/srcs/t3_source.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/23 17:54:52 by corvvs            #+#    #+#             */
-/*   Updated: 2022/02/23 18:20:33 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/02/23 18:26:55 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,7 +53,7 @@ static t_source	detect_source_type(int argc, char **argv)
 	if (argc == 1)
 		return (T3_SRC_TEXT);
 	if (argc == 2 && filepath[0] != '.'
-		&& ft_str_ensdwith(filepath, T3_EXTENSION_3D))
+		&& ft_str_endswith(filepath, T3_EXTENSION_3D))
 		return (T3_SRC_FILE_3D);
 	return (T3_SRC_FILE_UNEXPECTED);
 }

--- a/srcs/t3_source.c
+++ b/srcs/t3_source.c
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/23 17:54:52 by corvvs            #+#    #+#             */
-/*   Updated: 2022/02/23 18:26:55 by corvvs           ###   ########.fr       */
+/*   Updated: 2022/02/23 18:29:58 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,7 +52,7 @@ static t_source	detect_source_type(int argc, char **argv)
 		return (T3_SRC_TOO_MANY);
 	if (argc == 1)
 		return (T3_SRC_TEXT);
-	if (argc == 2 && filepath[0] != '.'
+	if (argc == 2 && strlen(filepath) > strlen(T3_EXTENSION_3D)
 		&& ft_str_endswith(filepath, T3_EXTENSION_3D))
 		return (T3_SRC_FILE_3D);
 	return (T3_SRC_FILE_UNEXPECTED);

--- a/srcs/t3_source.c
+++ b/srcs/t3_source.c
@@ -1,0 +1,86 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   t3_source.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/02/23 17:54:52 by corvvs            #+#    #+#             */
+/*   Updated: 2022/02/23 18:20:33 by corvvs           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "term3d.h"
+
+// bind STDIN_FILENO to tty(for key-control).
+static int	stdin_to_tty(void)
+{
+	close(STDIN_FILENO);
+	return (dup2(STDOUT_FILENO, STDIN_FILENO));
+}
+
+static void	hande_text(t_system *system)
+{
+	system->src_mode = T3_SRC_TEXT;
+	if (!t3_read_glyphs(system->glyphs))
+	{
+		dprintf(STDERR_FILENO, T3_COLOR_YELLOW
+			"Error: %s: failed to read glyth file."
+			T3_COLOR_RESET "\n", T3_GLYPH_FILE);
+		exit(1);
+	}
+	t3_scan_message(system);
+	stdin_to_tty();
+}
+
+static void	handle_file_3d(t_system *system, const char *filename)
+{
+	system->src_mode = T3_SRC_FILE_3D;
+	system->points_original = t3_read_vectors_from_file(filename);
+	if (!system->points_original)
+		exit(1);
+	system->n_points = 0;
+	while (isfinite(system->points_original[system->n_points][0]))
+		system->n_points += 1;
+}
+
+static t_source	detect_source_type(int argc, char **argv)
+{
+	const char	*filepath = argv[1];
+
+	if (argc > 2)
+		return (T3_SRC_TOO_MANY);
+	if (argc == 1)
+		return (T3_SRC_TEXT);
+	if (argc == 2 && filepath[0] != '.'
+		&& ft_str_ensdwith(filepath, T3_EXTENSION_3D))
+		return (T3_SRC_FILE_3D);
+	return (T3_SRC_FILE_UNEXPECTED);
+}
+
+void	t3_read_source(t_system *system, int argc, char **argv)
+{
+	const char	*filepath = argv[1];
+
+	system->src_mode = detect_source_type(argc, argv);
+	if (system->src_mode == T3_SRC_TEXT)
+		hande_text(system);
+	else if (system->src_mode == T3_SRC_FILE_3D)
+		handle_file_3d(system, filepath);
+	else
+	{
+		if (system->src_mode == T3_SRC_TOO_MANY)
+		{
+			dprintf(STDERR_FILENO, T3_COLOR_YELLOW
+				"Error: too mamy argument."
+				T3_COLOR_RESET "\n");
+		}
+		else if (system->src_mode == T3_SRC_FILE_UNEXPECTED)
+		{
+			dprintf(STDERR_FILENO, T3_COLOR_YELLOW
+				"Error: %s: we expect .3d extension only."
+				T3_COLOR_RESET "\n", filepath);
+		}
+		exit(1);
+	}
+}


### PR DESCRIPTION
## やったこと

- 入力(argv)の個数チェックとファイル拡張子のチェックをまとめて実施するようにした。
- その辺の処理を新しいファイルに分離した。結果`main.c`は`main`関数のみとなった。
- (以下本題と関係ないやつ)
  - 構造体メンバの名称を適切なものに変更。
  - コメントも変更。
  - ターミナル出力時の`write`サイズとして前もって計算しといた値を使う

## やらないこと

## テスト

## その他
